### PR TITLE
Bug: edit sends request to /upload

### DIFF
--- a/sdk/src/client/edit_file.rs
+++ b/sdk/src/client/edit_file.rs
@@ -61,7 +61,7 @@ where
 
         let response = self
             .http_client
-            .post(format!("{}/upload", SHDW_DRIVE_ENDPOINT))
+            .post(format!("{}/edit", SHDW_DRIVE_ENDPOINT))
             .multipart(form)
             .send()
             .await?;


### PR DESCRIPTION
Change endpoint form `/upload` to `/edit`. Closes #33 