### PR TITLE
Update Cargo.toml

### DIFF
--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 [dependencies]
 concat-arrays = "0.1.2"
 ed25519-dalek = "1.0.1"
+ntapi = "0.4.1"
 pyo3 = { version = "0.17.3", features = ["extension-module"] }
 reqwest = "0.11.14"
 shadow-drive-sdk = { path = "../sdk/", version = "0.6.3" }


### PR DESCRIPTION
Added dependency ntapi which is needed for 'pip install shadow_drive' to compile on native Windows 11, i.e. not WSL. (Only tested compiling on Windows and linux systems with this change.)